### PR TITLE
Joystick Deadband Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 **/*.pyc
 **/__pycache__/
+
+build

--- a/nodes/input_logx3dpro.py
+++ b/nodes/input_logx3dpro.py
@@ -4,8 +4,8 @@ from wreadinput import DeviceAxis, DeviceShape, DeviceKey, default_node
 
 # TODO check to make sure these are what actually get mapped by evdev
 SHAPE_LOGX3DPRO = DeviceShape()\
-    .with_axis(DeviceAxis.ABS_X, 'stick_x')\
-    .with_axis(DeviceAxis.ABS_Y, 'stick_y', 1, -1)\
+    .with_axis(DeviceAxis.ABS_X, 'stick_x', deadband = 0.1)\
+    .with_axis(DeviceAxis.ABS_Y, 'stick_y', 1, -1, deadband = 0.1)\
     .with_axis(DeviceAxis.ABS_RZ, 'stick_twist')\
     .with_axis(DeviceAxis.ABS_THROTTLE, 'throttle', 0, 1)\
     .with_axis(DeviceAxis.ABS_HAT0X, 'pov_x')\

--- a/nodes/input_xbox360.py
+++ b/nodes/input_xbox360.py
@@ -4,10 +4,10 @@ from wreadinput import DeviceAxis, DeviceShape, DeviceKey, default_node
 
 # TODO check to make sure these are what actually get mapped by evdev
 SHAPE_XBOX360 = DeviceShape()\
-    .with_axis(DeviceAxis.ABS_X, 'stick_left_x')\
-    .with_axis(DeviceAxis.ABS_Y, 'stick_left_y')\
-    .with_axis(DeviceAxis.ABS_RX, 'stick_right_x')\
-    .with_axis(DeviceAxis.ABS_RY, 'stick_right_y')\
+    .with_axis(DeviceAxis.ABS_X, 'stick_left_x', deadband = 0.1)\
+    .with_axis(DeviceAxis.ABS_Y, 'stick_left_y', deadband = 0.1)\
+    .with_axis(DeviceAxis.ABS_RX, 'stick_right_x', deadband = 0.1)\
+    .with_axis(DeviceAxis.ABS_RY, 'stick_right_y', deadband = 0.1)\
     .with_axis(DeviceAxis.ABS_Z, 'trigger_left', 0, 1)\
     .with_axis(DeviceAxis.ABS_RZ, 'trigger_right', 0, 1)\
     .with_axis(DeviceAxis.ABS_HAT0X, 'pov_x')\

--- a/src/wreadinput/device.py
+++ b/src/wreadinput/device.py
@@ -39,8 +39,8 @@ class AxisBuf:
 
         # Set up slopes and output offsets, as well as the bounds for the 3 regions introduced by the deadband
         self._scale = (to_max - to_min) / ((1 - deadband) * (from_max - from_min))
-        self._offset = (from_max + from_min) / 2
-        input_center = (to_max + to_min) / 2
+        self._offset = (to_max + to_min) / 2
+        input_center = (from_max + from_min) / 2
         self._deadband_high = deadband * (from_max - input_center) + input_center
         self._deadband_low = deadband * (from_min - input_center) + input_center
         

--- a/src/wreadinput/shape.py
+++ b/src/wreadinput/shape.py
@@ -17,6 +17,8 @@ class AxisDefinition:
             The minimum value to output for the axis.
         max_val : float
             The maximum value to output for the axis.
+        deadband : float
+            The area around the center of the input that should be centered in the output, as a percentage.
         """
         self.name = name
         self.min_val = min_val
@@ -49,6 +51,8 @@ class DeviceShape:
             The minimum value to output for the axis.
         max_val : float
             The maximum value to output for the axis.
+        deadband : float
+            The area around the center of the input that should be centered in the output, as a percentage.
 
         Returns
         -------

--- a/src/wreadinput/shape.py
+++ b/src/wreadinput/shape.py
@@ -6,7 +6,7 @@ from .util.evdev_const import DeviceAxis, DeviceCaps, DeviceEventType, DeviceKey
 class AxisDefinition:
     """Represents an absolute axis declaration in a device shape."""
     
-    def __init__(self, name: str, min_val: float, max_val: float):
+    def __init__(self, name: str, min_val: float, max_val: float, deadband: float):
         """Creates a new axis definition with the given properties.
 
         Parameters
@@ -21,6 +21,7 @@ class AxisDefinition:
         self.name = name
         self.min_val = min_val
         self.max_val = max_val
+        self.deadband = deadband
 
 class DeviceShape:
     """Represents the set of controls that are characteristic of an input device.
@@ -37,7 +38,7 @@ class DeviceShape:
         self.keys: Dict[DeviceKey, str] = {}
         self._names: Set[str] = set() # track the names that have already been used
 
-    def with_axis(self, axis: DeviceAxis, name: str, min_val: float = -1, max_val: float = 1) -> 'DeviceShape':
+    def with_axis(self, axis: DeviceAxis, name: str, min_val: float = -1, max_val: float = 1, deadband: float = 0) -> 'DeviceShape':
         """Specifies an absolute axis for the device shape.
 
         Parameters
@@ -61,7 +62,7 @@ class DeviceShape:
         """
         if name in self._names:
             raise ValueError(f'A control named "{name}" already exists!')
-        self.axes[axis] = AxisDefinition(name, min_val, max_val)
+        self.axes[axis] = AxisDefinition(name, min_val, max_val, deadband)
         self._names.add(name)
         return self
 


### PR DESCRIPTION
This PR implements deadband support for axis-type controls in the `wreadinput` library.  A optional deadband parameter (default: 0) is added to axis definitions for controller configurations to clamp output near the center of the input range to the center of the output range.  Output outside of the deadband zone is scaled linearly from the edges of the deadband to avoid discontinuous jumps in controller output.  This helps compensate for joystick drift and provide more reliable controls.

This is the 'better implementation' mentioned in WisconsinRobotics/WRover_Software#14.